### PR TITLE
Fix to support ART and Android >= 7.1.1

### DIFF
--- a/harness/Android.mk
+++ b/harness/Android.mk
@@ -3,15 +3,14 @@ LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := harness.c server.c vm.c
-LOCAL_C_INCLUDES := $(LOCAL_PATH)
-#${ANDROID_NDK_ROOT}/platforms/android-21/arch-arm/usr/include/
+LOCAL_C_INCLUDE := ${ANDROID_NDK_ROOT}/platforms/android-21/arch-arm/usr/include/
 
 LOCAL_MODULE := harness
 LOCAL_MODULE_TAGS := optional
 
 # Allow execution on android-16
 LOCAL_CFLAGS += -pie -fPIE
-LOCAL_LDFLAGS += -pie -fPIE
+LOCAL_LDFLAGS += -pie -fPIE -Wl,--export-dynamic
 
 APP_ABI := armeabi armeabi-v7a x86
 

--- a/harness/vm.c
+++ b/harness/vm.c
@@ -17,6 +17,10 @@ int init_jvm(JavaVM **p_vm, JNIEnv **p_env) {
   void *libdvm_dso = dlopen("libdvm.so", RTLD_NOW);
   void *libandroid_runtime_dso = dlopen("libandroid_runtime.so", RTLD_NOW);
 
+  if (!libdvm_dso) {
+    libdvm_dso = dlopen("libart.so", RTLD_NOW);
+  }
+
   if (!libdvm_dso || !libandroid_runtime_dso) {
     return -1;
   }
@@ -30,7 +34,12 @@ int init_jvm(JavaVM **p_vm, JNIEnv **p_env) {
   registerNatives_t registerNatives;
   registerNatives = (registerNatives_t) dlsym(libandroid_runtime_dso, "Java_com_android_internal_util_WithFramework_registerNatives");
   if (!registerNatives) {
-    return -3;
+    // From Android 7.1.1, withFramework functions are removed.
+    // If the "old" functions did not exists, use the new ones
+    registerNatives = (registerNatives_t) dlsym(libandroid_runtime_dso, "registerFrameworkNatives");
+    if(!registerNatives) {
+      return -3;
+    }
   }
 
   if (JNI_CreateJavaVM(&(*p_vm), &(*p_env), &args)) {
@@ -42,4 +51,32 @@ int init_jvm(JavaVM **p_vm, JNIEnv **p_env) {
   }
 
   return 0;
+}
+
+JNIEXPORT void InitializeSignalChain() {
+
+}
+
+JNIEXPORT void ClaimSignalChain() {
+
+}
+
+JNIEXPORT void UnclaimSignalChain() {
+
+}
+
+JNIEXPORT void InvokeUserSignalHandler() {
+
+}
+
+JNIEXPORT void EnsureFrontOfChain() {
+
+}
+
+JNIEXPORT void AddSpecialSignalHandlerFn() {
+
+}
+
+JNIEXPORT void RemoveSpecialSignalHandlerFn() {
+
 }


### PR DESCRIPTION
I have included some code on the vm.c file, in order to support ART and the newer versions of Android. After the changes, I saw diff uses the same on the native-shim code